### PR TITLE
RED-104: Add wordlist s3 resource for user registration build plan

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -751,6 +751,7 @@ resources:
       access_key_id: "((deploy-access-key-id))"
       secret_access_key: "((deploy-secret-access-key))"
       versioned_file: wordlist-short
+      region_name: eu-west-2
 
 resource_types: []
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -340,6 +340,7 @@ jobs:
             - User Signup API Tests
         - get: deploy-tools
         - get: runner
+        - get: wordlist-file
 
       - <<: *build-deployable
         params: 
@@ -741,6 +742,15 @@ resources:
     source:
       repository: ruby
       tag: '2.5.3-alpine3.9'
+
+  # S3 Resources
+  - name: wordlist-file
+    type: s3
+    source:
+      bucket: govwifi-wordlist
+      access_key_id: "((deploy-access-key-id))"
+      secret_access_key: "((deploy-secret-access-key))"
+      versioned_file: wordlist-short
 
 resource_types: []
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -556,6 +556,7 @@ jobs:
           passed: [Confirm Deploy to User Signup API Production]
         - get: deploy-tools
         - get: runner
+        - get: wordlist-file
 
       - <<: *build-deployable
         params: 


### PR DESCRIPTION
Adds an s3 resource allowing the wordlist file required by the user registration service to be downloaded and passed into the build task.