### PR TITLE
REP-462: Build raddb image

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -261,12 +261,19 @@ jobs:
           <<: *build-deployable-params
           REPOSITORY: 'govwifi/frontend'
           TAG: staging
-      
+
       - <<: *push-ecr
         put: frontend-repo
         params:
           <<: *push-ecr-params
           load_repository: govwifi/frontend
+          load_tag: staging
+
+      - <<: *push-ecr
+        put: raddb-repo
+        params:
+          <<: *push-ecr-params
+          load_repository: govwifi/raddb
           load_tag: staging
 
       - <<: *deploy
@@ -462,6 +469,13 @@ jobs:
         params:
           <<: *push-ecr-params
           load_repository: govwifi/frontend
+          load_tag: production
+
+      - <<: *push-ecr
+        put: raddb-repo
+        params:
+          <<: *push-ecr-params
+          load_repository: govwifi/raddb
           load_tag: production
 
       - <<: *deploy
@@ -661,6 +675,14 @@ resources:
     type: docker-image
     source:
       repository: "((deploy-repository))/govwifi/frontend"
+      tag: latest
+      aws_access_key_id: ((deploy-access-key-id))
+      aws_secret_access_key: ((deploy-secret-access-key))
+
+  - name: raddb-repo
+    type: docker-image
+    source:
+      repository: "((deploy-repository))/govwifi/raddb"
       tag: latest
       aws_access_key_id: ((deploy-access-key-id))
       aws_secret_access_key: ((deploy-secret-access-key))


### PR DESCRIPTION
The raddb image pulls certs and config from an S3 bucket using the aws
CLI and puts them in a shared volume.