### PR TITLE
Add missing raddb container deploy task

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -549,6 +549,14 @@ jobs:
           load_repository: govwifi/frontend
           load_tag: production
 
+      - <<: *build-deployable
+        task: build-raddb-image
+        params:
+          <<: *build-deployable-params
+          REPOSITORY: 'govwifi/raddb'
+          DOCKERFILE: src/Dockerfile.raddb
+          TAG: production
+
       - <<: *push-ecr
         put: raddb-repo
         params:


### PR DESCRIPTION
This causes the prod frontend deploy pipeline to fail as the raddb image is not pushed to ECR.