### PR TITLE
Add docker hub creds to main deploy pipline

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -22,6 +22,7 @@ x-tasks:
     # should output 'image/tag' based on "TAG"
     file: src/ci/tasks/build-deployable.yml
     params: &build-deployable-params
+      DOCKER_HUB_AUTHTOKEN_ENV: ((docker_hub_authtoken))
       TAG:
 
   push-ecr: &push-ecr

--- a/deploy.yml
+++ b/deploy.yml
@@ -807,12 +807,16 @@ resources:
     source:
       repository: mysql
       tag: '5.7'
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
   - name: nginx-image
     type: registry-image
     source:
       repository: nginx
       tag: alpine
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
   # Admin docker caching
   - name: admin-ruby-image
@@ -820,6 +824,8 @@ resources:
     source:
       repository: ruby
       tag: '2.6.2'
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
   
   # Auth docker caching
   - name: auth-ruby-image
@@ -827,6 +833,8 @@ resources:
     source:
       repository: ruby
       tag: '2.5.3-alpine'
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
   
   # Logging docker caching
   - name: logging-ruby-image
@@ -834,6 +842,8 @@ resources:
     source:
       repository: ruby
       tag: '2.6.1-alpine'
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
   
   # User Signup docker caching
   - name: user-signup-ruby-image
@@ -841,6 +851,8 @@ resources:
     source:
       repository: ruby
       tag: '2.5.1-alpine'
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
   
   # Frontend docker caching
   - name: frontend-alpine-image
@@ -855,6 +867,8 @@ resources:
     source:
       repository: ruby
       tag: '2.5.3-alpine3.9'
+      username: ((docker_hub_username))
+      password: ((docker_hub_authtoken))
 
   # S3 Resources
   - name: wordlist-file


### PR DESCRIPTION
Add Docker Hub credentials and auth token to our main deploy pipeline. These will be used to pull docker images at various stages in the pipeline.

Note: we add the auth token to the `build-deployable` task so it can use the value in individual repos. The task corresponds to this `<app repo>/ci/tasks/build-deployable.yml` file in individual repos.

We need to add these credentials because Docker Hub will introduce rate limiting on 1 Nov.

Paired with @camdesgov 