### PR TITLE
Add staging and production build tasks for frontend base image

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -327,8 +327,23 @@ jobs:
         - get: runner
 
       - <<: *build-deployable
-        task: build-frontend-image
+        task: build-frontend-base-image
         params: 
+          <<: *build-deployable-params
+          REPOSITORY: 'govwifi/frontend-base'
+          DOCKERFILE: src/Dockerfile.base
+          TAG: staging
+
+      - <<: *push-ecr
+        put: frontend-base-repo
+        params:
+          <<: *push-ecr-params
+          load_repository: govwifi/frontend-base
+          load_tag: staging
+
+      - <<: *build-deployable
+        task: build-frontend-image
+        params:
           <<: *build-deployable-params
           REPOSITORY: 'govwifi/frontend'
           TAG: staging
@@ -540,9 +555,23 @@ jobs:
       - <<: *build-deployable
         params: 
           <<: *build-deployable-params
-          REPOSITORY: 'govwifi/frontend'
+          REPOSITORY: 'govwifi/frontend-base'
+          DOCKERFILE: src/Dockerfile.base
           TAG: production
       
+      - <<: *push-ecr
+        put: frontend-base-repo
+        params:
+          <<: *push-ecr-params
+          load_repository: govwifi/frontend-base
+          load_tag: production
+
+      - <<: *build-deployable
+        params:
+          <<: *build-deployable-params
+          REPOSITORY: 'govwifi/frontend'
+          TAG: production
+
       - <<: *push-ecr
         put: frontend-repo
         params:
@@ -758,6 +787,14 @@ resources:
     type: docker-image
     source:
       repository: "((deploy-repository))/govwifi/authorisation-api"
+      tag: latest
+      aws_access_key_id: ((deploy-access-key-id))
+      aws_secret_access_key: ((deploy-secret-access-key))
+
+  - name: frontend-base-repo
+    type: docker-image
+    source:
+      repository: "((deploy-repository))/govwifi/frontend-base"
       tag: latest
       aws_access_key_id: ((deploy-access-key-id))
       aws_secret_access_key: ((deploy-secret-access-key))


### PR DESCRIPTION
At this stage, we are only adding jobs that build the base image. Down the line, the frontend image will use this base image.

This is dependant on: https://github.com/alphagov/govwifi-frontend/pull/113