### PR TITLE
Fix the self-update job so it does not fail anymore.

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -161,16 +161,11 @@ groups:
 
 jobs:
   - name: self-update
-    serial: true
     plan:
-    - get: deploy-tools
-      trigger: true
-    - put: deploy-pipeline
-      params:
-        pipelines:
-          - name: deploy
-            team: govwifi
-            config_file: deploy-tools/deploy.yml
+      - get: deploy-tools
+        trigger: true
+      - set_pipeline: deploy-tools
+        file: deploy-tools/deploy.yml
 
   ###### Tests + Lints ######
   - name: Admin Tests
@@ -807,15 +802,6 @@ resources:
     source:
       repository: "((readonly_private_ecr_repo_url))"
       tag: concourse-runner-latest
-
-  # this pipeline
-  - name: deploy-pipeline
-    type: concourse-pipeline
-    source:
-      teams:
-        - name: govwifi
-          username: govwifi
-          password: ((readonly_local_user_password))
 
   # sources
   - name: deploy-tools


### PR DESCRIPTION
The self-update job uses the tech-ops gem which uses a deprecated
way of self-updating using fly (which fails because of a version
mismatch)

The new way uses the built-in 'set_pipeline' step in deploy.yml.

Trello: https://trello.com/c/DvluAxH1/615-unblock-the-self-update-concourse-pipeline-doc-handover-from-robin