### PR TITLE
changed branch to master now the other branch has been merged and deleted

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -884,7 +884,7 @@ resources:
     type: git
     source:
       uri: https://github.com/alphagov/govwifi-database-backup.git
-      branch: add_concourse_ci
+      branch: master
 
   # Docker repositories
   - name: admin-repo


### PR DESCRIPTION
**WHAT**

Change the branch that the Concourse deploy -> Database Backup uses 

**WHY**

The branch it was looking at was out of date and has now been merged into `master` so has stopped the pipeline working