### PR TITLE
Fix self-update `set_pipeline` value

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -165,7 +165,7 @@ jobs:
     plan:
       - get: deploy-tools
         trigger: true
-      - set_pipeline: deploy-tools
+      - set_pipeline: self
         file: deploy-tools/deploy.yml
 
   ###### Tests + Lints ######


### PR DESCRIPTION
### What

Change `set_pipeline` value from `deploy-tools` to `self`.

* `self` is a special value in Concourse which allows the current pipeline to update its own config.
* When we migrated to the `set_pipeline` command, we set the value to `deploy-tools` which creates a mirror pipeline to `deploy` in the "self-update" job instead of updating the `deploy` pipeline's own config.
* See a [similar change made on the `govwifi-dev-docs` repo](https://github.com/alphagov/govwifi-dev-docs/commit/5e6f64c9e9d6503105abc6990c27cbf96110ef2d) as well as the [Concourse documentation for `set_pipeline`](https://concourse-ci.org/jobs.html#set-pipeline-step).

### Why

When we run the "self-update" job on the `deploy` pipeline, instead of updating the pipeline's config it creates a replica pipeline called `deploy-tools`. This replica tries to retrieve credentials from Big Concourse which aren't configured and is costing the Automate team time and resources.

See this [Trello card](https://trello.com/c/zRUJDreI/1167-address-how-we-retrieve-unused-secrets-in-concourse)

