### PR TITLE
fix typo (missing t) in function name

### DIFF
--- a/aws-helpers.sh
+++ b/aws-helpers.sh
@@ -31,7 +31,7 @@ function get_launch_type() {
         --query 'services[0].launchType'
 }
 
-function get_plaform_version() {
+function get_platform_version() {
   local cluster_name="${1}"
   local service_name="${2}"
 


### PR DESCRIPTION
**WHAT**

Slight typo here…
https://github.com/alphagov/govwifi-concourse-deploy-pipeline/commit/489016ac9675ae7833ba90e5abf6953a9299b618

is:
`function get_plaform_version()`
should be:
`function get_platform_version()`

**WHY**

Spelling