### PR TITLE
removed the line stating platform version for test

### DIFF
--- a/aws-helpers.sh
+++ b/aws-helpers.sh
@@ -58,7 +58,6 @@ function run_task_with_command() {
         --cluster "${cluster_name}" \
         --task-definition "${task_definition}" \
         --launch-type "${launch_type}" \
-        --platform-version "${platform_version}" \
         --network-configuration "${network_config}" \
         --count 1 \
         --override "$(override_command_structure "${docker_service_name}" "${command}")"


### PR DESCRIPTION
**WHAT**

Rebreaking ecs task by removing the platform_version to be default/latest/1.4.0

**WHY**

Check to see if the smoke tests become "happy" again