### PR TITLE
Remove temp reference for staging admin deploy task

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -357,7 +357,7 @@ jobs:
       - <<: *staging-deploy
         params:
           <<: *staging-deploy-params
-          STAGE: staging-temp
+          STAGE: staging
 
   - name: Frontend Staging Deploy
     max_in_flight: 1


### PR DESCRIPTION
### What

Change `staging-temp` to `staging`.

### Why
The "temp suffix"  was a useful distinguisher when we had two staging environments, it is no longer necessary.

Link to Trello card (if applicable): 
https://trello.com/c/LZDJ09Om/1776-update-references-to-staging-temp
