### PR TITLE
Change STAGE parameter from "staging-temp" to "staging" for Admin API.

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -357,7 +357,7 @@ jobs:
       - <<: *staging-deploy
         params:
           <<: *staging-deploy-params
-          STAGE: staging-temp
+          STAGE: staging
 
   - name: Frontend Staging Deploy
     max_in_flight: 1


### PR DESCRIPTION
### What
Change STAGE parameter from "staging-temp" to "staging" for Admin API.

### Why
The "temp suffix" was a useful distinguisher when we had two staging
environments, it is no longer necessary. The changes to environment name in
https://github.com/alphagov/govwifi-terraform/pull/617 impact the Admin API’s
cluster name and service name. In order for the Admin deploy task to run
correctly and restart the related ECS service, the value for `STAGE` and the
`env_name` used in govwifi-terraform must match. The scripts that help to
deploy and restart the cluster services reference the value passed in `STAGE`
(please see [this file](https://github.com/alphagov/govwifi-concourse-deploy-pipeline/blob/master/aws-helpers.sh#L5-L10) for an example of this use).

Link to Trello card (if applicable): https://trello.com/c/BdeRMbFs/1820-practice-bringing-up-a-new-account-from-scratch-in-dr-account
