### PR TITLE
Update the wordlist bucket name

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -1132,7 +1132,7 @@ resources:
   - name: wordlist-file
     type: s3
     source:
-      bucket: govwifi-wordlist
+      bucket: wordlist-20211214162103864400000001
       access_key_id: "((production-deploy-access-key-id))"
       secret_access_key: "((production-deploy-secret-access-key))"
       versioned_file: wordlist-short


### PR DESCRIPTION
### What
Update the wordlist bucket name

### Why
This is for the change to using bucket_prefix'es, rather than bucket
names including the environment or subdomain.

It's not particularly neat, but it shouldn't change often.


Link to Trello card: https://trello.com/c/BdeRMbFs/1820-finish-off-the-migration-to-staging-in-a-separate-aws-account