### PR TITLE
Switch to using python3 in aws-helpers.sh

### DIFF
--- a/aws-helpers.sh
+++ b/aws-helpers.sh
@@ -66,7 +66,7 @@ function run_task_with_command() {
 
 function form_command_override() {
   local override_command="${1}"
-  override_command="${override_command}" python -c \
+  override_command="${override_command}" python3 -c \
     'import os,json,shlex; print(json.dumps(shlex.split(os.environ["override_command"])))'
 }
 


### PR DESCRIPTION
### What
Switch to using python3 in aws-helpers.sh

### Why
This matches up with the runner image change to a newer Docker
version. It seems to be missing python, so switch to python3.
