### PR TITLE
Change the safe-restarter-ruby-image to match the Dockerfile

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -1108,7 +1108,7 @@ resources:
     type: registry-image
     source:
       repository: ruby
-      tag: '2.5.3-alpine3.9'
+      tag: '3.0.2-alpine'
       username: ((docker_hub_username))
       password: ((docker_hub_authtoken))
 


### PR DESCRIPTION
### What
Change the safe-restarter-ruby-image to match the Dockerfile

### Why
This is ridiculous, but so is Docker, so ¯\_(ツ)_/¯
