### PR TITLE
Change ECS service name in staging

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -895,7 +895,7 @@ resources:
   - name: staging-auth-api-repo
     type: docker-image
     source:
-      repository: "((staging-deploy-repository))/govwifi/authorisation-api"
+      repository: "((staging-deploy-repository))/govwifi/authentication-api"
       tag: latest
       aws_access_key_id: ((staging-deploy-access-key-id))
       aws_secret_access_key: ((staging-deploy-secret-access-key))


### PR DESCRIPTION
### What
We are in the process of making any references to the authentication api infrastructure consistent, and we are testing this change in Staging.

### Why
At present we are using the name "authentication-api" and "authorization-api" to refer to the same things, which is confusing. This change is part of rectifying that.

Link to Jira card (if applicable):
https://technologyprogramme.atlassian.net/jira/software/projects/GW/boards/251?selectedIssue=GW-204
